### PR TITLE
Allow symfony/dependency-injection v7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^8.1",
     "psr/log": "^2.0 || ^3.0",
-    "symfony/dependency-injection": "^5.4 || ^6.0"
+    "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "phpcq/runner-bootstrap": "^1.0@dev"


### PR DESCRIPTION
I wonder whether the dependency can also be defined as a dev-requirement.